### PR TITLE
Fix #158 : 渉外局Web総括の文言修正

### DIFF
--- a/src/soukatsu/syogai/05_web.tex
+++ b/src/soukatsu/syogai/05_web.tex
@@ -13,7 +13,7 @@
   \item 会誌の公開
 \end{itemize}
 
-Advent CalendarについてはAdvent Calendar総括で述べる．
+Advent CalendarについてはAdvent Calendar総括で述べた．
 
 イベントの記事投稿に関しては，立命の家や学園祭，ハッカソンなどのイベントが開催されなかったこともあり，記事投稿することはできなかった．
 


### PR DESCRIPTION
`Advent Calendar 総括で述べる`
を
`Advent Calendar 総括で述べた`
に修正